### PR TITLE
(doc) Create dev/admin tools

### DIFF
--- a/PRESS-RELEASE.md
+++ b/PRESS-RELEASE.md
@@ -1,4 +1,4 @@
-# Project Name #
+# tunavid.io #
 
 <!-- 
 > This material was originally posted [here](http://www.quora.com/What-is-Amazons-approach-to-product-development-and-product-management). It is reproduced here for posterities sake.
@@ -23,7 +23,7 @@ Once the project moves into development, the press release can be used as a touc
   > Speed through videos with live search and highlight reel generation
 
 ## Summary ##
-  > tuna.io is a full service video platform that allows users to upload and watch videos. We transcribe and index all videos uploaded to our platform to provide you with an efficient way of scanning through videos and cut through the noise to find exactly what you're looking for.
+  > tunavid.io is a full service video platform that allows users to upload and watch videos. We transcribe and index all videos uploaded to our platform to provide you with an efficient way of scanning through videos and cut through the noise to find exactly what you're looking for.
 
 ## Problem ##
   > High quality video content (for news, education, etc.) is being created at an exponential rate, but our means of video consumption has not kept up with this rate of growth.
@@ -35,7 +35,7 @@ Once the project moves into development, the press release can be used as a touc
   > We are the sixth fastest fish in the sea, but commonly misrepresented as the fastest (we're cool with that).
 
 ## How to Get Started ##
-  > Visit tuna.io to begin browsing and uploading awesome content!
+  > Visit [tunavid.io](http://tunavid.io) to begin browsing and uploading awesome content!
 
 ## Customer Quote ##
   > "This is dope. I can finally find my shit." - Bill Zito

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 func main() {
   r := mux.NewRouter().StrictSlash(true)
 
+  r.PathPrefix("/api/docs/").Handler(http.StripPrefix("/api/docs/",http.FileServer(http.Dir("./doc/"))))
+
   /*-------------------------------------
    *         `/api` router
    *------------------------------------*/
@@ -31,7 +33,7 @@ func main() {
   /*-------------------------------------
    *      `/` static file server
    *------------------------------------*/
-  r.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.Dir("client"))))
+  r.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.Dir("./client/"))))
 
   // Start up server and error log
   log.Println("Listening at port 3000")

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/tuna-io/tuna-io#readme",
   "dependencies": {
-    "api-doc": "^4.0.0"
+    "api-doc": "^4.0.0",
+    "redis-commander": "^0.4.2"
   }
 }


### PR DESCRIPTION
Upon merge, this PR will allow the following tools to be made available (after deployment)

- [x] [redis.tunavid.io](http://redis.tunavid.io) will now show a live database view with easy editing of keys, values, and other db management tools (much like mLab does for mongoDB)
- [x] [tunavid.io/api/docs](http://tunavid.io/api/docs) will now show all the documentation for the backend, including all API endpoints, parameters accepted, and sample success/error messages