### PR TITLE
(feat) Serve docs rather than client on API server

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,8 +10,6 @@ import (
 func main() {
   r := mux.NewRouter().StrictSlash(true)
 
-  r.PathPrefix("/api/docs/").Handler(http.StripPrefix("/api/docs/",http.FileServer(http.Dir("./doc/"))))
-
   /*-------------------------------------
    *         `/api` router
    *------------------------------------*/
@@ -33,7 +31,7 @@ func main() {
   /*-------------------------------------
    *      `/` static file server
    *------------------------------------*/
-  r.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.Dir("./client/"))))
+  r.PathPrefix("/").Handler(http.StripPrefix("/", http.FileServer(http.Dir("./doc/"))))
 
   // Start up server and error log
   log.Println("Listening at port 3000")


### PR DESCRIPTION
Resolves #33

Tiny pull request that makes available the following via a small tweak (most of the work done on VPS):

- [x] docs now available on http://docs.tunavid.io
- [x] redis GUI still available on http://redis.tunavid.io
- [x] client now served on http://tunavid.io